### PR TITLE
Fix mobile no. rendering

### DIFF
--- a/src/customiser/components/CustomiserGeneral.tsx
+++ b/src/customiser/components/CustomiserGeneral.tsx
@@ -28,7 +28,7 @@ interface AdditionalInfo {
 type Form = Info & AdditionalInfo;
 
 interface CustomiserGeneralProps {
-    info: Info;
+    info: Form;
     setInfo: React.Dispatch<React.SetStateAction<Form>>;
 }
 
@@ -77,7 +77,7 @@ const CustomiserGeneral: React.FC<CustomiserGeneralProps> = ({ info, setInfo }) 
         const countryCode = parsedPhoneNumber ? parsedPhoneNumber.country : null;
 
         const updatedGeneralInfo: Form = {
-            ...info,
+            ...form,
             firstName: form.firstName,
             lastName: form.lastName,
             email: form.email,

--- a/src/customiser/components/CustomiserGeneral.tsx
+++ b/src/customiser/components/CustomiserGeneral.tsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import 'react-phone-number-input/style.css';
 import PhoneInput from 'react-phone-number-input';
+import E164Number from 'react-phone-number-input';
 import { formatPhoneNumberIntl, parsePhoneNumber, PhoneNumber } from 'react-phone-number-input';
 import { useState, useRef } from 'react';
 import { Tooltip } from 'react-tooltip';
@@ -33,7 +34,7 @@ interface CustomiserGeneralProps {
 }
 
 const CustomiserGeneral: React.FC<CustomiserGeneralProps> = ({ info, setInfo }) => {
-    const [mobile, setMobile] = useState<any>(null); // As required for PhoneInput component
+    // const [mobile, setMobile] = useState<any>(null); // As required for PhoneInput component
     const [form, setForm] = useState<Form>({
         firstName: '',
         lastName: '',
@@ -65,6 +66,13 @@ const CustomiserGeneral: React.FC<CustomiserGeneralProps> = ({ info, setInfo }) 
         setForm({
             ...form,
             [e.target.name]: value,
+        });
+    };
+
+    const handleMobileChange = (value: any): void => {
+        setForm({
+            ...form,
+            mobile: value || null,
         });
     };
 
@@ -154,7 +162,7 @@ const CustomiserGeneral: React.FC<CustomiserGeneralProps> = ({ info, setInfo }) 
                             name="mobileInput"
                             placeholder="Enter phone number"
                             value={form.mobile || undefined}
-                            onChange={setMobile}
+                            onChange={handleMobileChange}
                             required
                         />
                         <div className="flex gap-2 mt-2">

--- a/src/viewer/components/ViewerGeneral.tsx
+++ b/src/viewer/components/ViewerGeneral.tsx
@@ -27,7 +27,7 @@ const ViewerGeneral: React.FC<ViewerGeneralProps> = ({ info }) => {
                         {info.firstName} {info.lastName}
                     </h1>
                     <p>
-                        {info.email} | {info.mobile}
+                        {info.email}{info.mobile && ` | ${info.mobile}`}
                         {info.portfolioInputVis ? ` | ${info.portfolio}` : ''}
                         {info.gitHubInputVis ? ` | github.com/${info.gitHub} ` : ''}
                         {info.stateInputVis ? ` | ${info.state}` : ''}


### PR DESCRIPTION
---
name: Pull Request
about: Fix mobile no. rendering
title: 'Feature: Fix mobile no. rendering'
labels: enhancement
assignees: @kevinweejh 
---

**Related Issue(s)**
#25 

**Problem / Motivation**
The 'Mobile No.' in the 'General Info' tab is not saved by the `useState` setter function correctly, as such, the Viewer component is not able to render the 'Mobile No.' correctly. 

**Solution**
Drop the `[mobile, setMobile]` state and setter function, as they are not needed for the mobile no. to be saved, updated, or removed. 

**Testing Done**
Manual testing in test environment for feature branch `issue-25-fix`. 

**Screenshots**
![image](https://github.com/kevinweejh/resu-me/assets/34761000/3c51c250-31b2-4183-a394-cd6ac2e94937)


**Checklist:**

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

**Additional Notes**
NIL
